### PR TITLE
Fix reveal initialization conditional

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -8,7 +8,7 @@
   // https://github.com/hakimel/reveal.js#configuration
   Reveal.initialize({
     {% if site.reveal %}
-    {% for attr in site.reveal %}{{attr[0]}}: {% unless {attr[1]} == false or {attr[1]} == true or {attr[0]} == "width" or {attr[0]} == "height" %}'{{attr[1]}}',{% else %}{{attr[1]}},{% endunless %}
+    {% for attr in site.reveal %}{{attr[0]}}: {% unless attr[1] == false or attr[1] == true or attr[0] == "width" or attr[0] == "height" %}'{{attr[1]}}',{% else %}{{attr[1]}},{% endunless %}
     {% endfor %}
     {% endif %}
 


### PR DESCRIPTION
## Summary
- remove invalid Liquid expressions when iterating over `site.reveal`

## Testing
- `script/cibuild` *(fails: bundler not compatible with current Ruby version)*

------
https://chatgpt.com/codex/tasks/task_e_6847849f8f148332a81fd9572539df59